### PR TITLE
Show code for all variants

### DIFF
--- a/_layouts/diag.html
+++ b/_layouts/diag.html
@@ -9,12 +9,33 @@ layout: default
 
 <h3>{{ layout.display_name }} Code</h3>
 
+{% if page.variants %}
+These diagram variants were created from the following PlantUML code:
+{% else %}
 This diagram was created from the following PlantUML code:
+{% endif %}
+
+<details>
+    <summary>Show code of Main {{ page.display_name }}<br>
+        or go directly to <a href="{{ site.github.repository_url }}/blob/main/collections/_{{ page.kind }}/input/{{ page.name }}.puml" target="_blank">{{ page.name }}.puml on GitHub</a></summary>
 
 {% capture my_code %}{% include_relative input/{{ page.name }}.puml %}{% endcapture %}
 {% highlight plantuml %}
 {{ my_code | strip }}
 {% endhighlight %}
+</details>
+
+{% for variant in page.variants %}
+<details>
+    <summary>Show code of {{ variant.display_name }}<br>
+        or go directly to <a href="{{ site.github.repository_url }}/blob/main/collections/_{{ page.kind }}/input/{{ variant.name }}.puml" target="_blank">{{ variant.name }}.puml on GitHub</a></summary>
+
+{% capture my_code %}{% include_relative input/{{ variant.name }}.puml %}{% endcapture %}
+{% highlight plantuml %}
+{{ my_code | strip }}
+{% endhighlight %}
+</details>
+{% endfor %}
 
 <h3>Available Themes</h3>
 

--- a/index.md
+++ b/index.md
@@ -26,31 +26,31 @@ Context:
 
 View all the themes
 
-* [Themes Overview]({{ site.baseurl }}/{% link pages/themes/index.md %})
-* [View all themes in an image gallery]({{ site.baseurl }}/{% link pages/themes/gallery.md %})
-* [View all themes in a table]({{ site.baseurl }}/{% link pages/themes/table.md %})
-* [View all themes in a big list _(classic approach)_]({{ site.baseurl }}/{% link pages/themes/list.md %})
+* [Themes Overview]({{ site.baseurl }}{% link pages/themes/index.md %})
+* [View all themes in an image gallery]({{ site.baseurl }}{% link pages/themes/gallery.md %})
+* [View all themes in a table]({{ site.baseurl }}{% link pages/themes/table.md %})
+* [View all themes in a big list _(classic approach)_]({{ site.baseurl }}{% link pages/themes/list.md %})
 
 View all the skins
 
-* [Skins Overview]({{ site.baseurl }}/{% link pages/skins/index.md %})
-* [View all skins in an image gallery]({{ site.baseurl }}/{% link pages/skins/gallery.md %})
-* [View all skins in a table]({{ site.baseurl }}/{% link pages/skins/table.md %})
-* [View all skins in a big list _(classic approach)_]({{ site.baseurl }}/{% link pages/skins/list.md %})
+* [Skins Overview]({{ site.baseurl }}{% link pages/skins/index.md %})
+* [View all skins in an image gallery]({{ site.baseurl }}{% link pages/skins/gallery.md %})
+* [View all skins in a table]({{ site.baseurl }}{% link pages/skins/table.md %})
+* [View all skins in a big list _(classic approach)_]({{ site.baseurl }}{% link pages/skins/list.md %})
 
 View all the diagrams
 
-* [Diagrams Overview]({{ site.baseurl }}/{% link pages/diagrams/index.md %})
-* [View all diagrams in an image gallery]({{ site.baseurl }}/{% link pages/diagrams/gallery.md %})
-* [View all diagrams in a table]({{ site.baseurl }}/{% link pages/diagrams/table.md %})
-* [View all diagrams in a big list _(classic approach)_]({{ site.baseurl }}/{% link pages/diagrams/list.md %})
+* [Diagrams Overview]({{ site.baseurl }}{% link pages/diagrams/index.md %})
+* [View all diagrams in an image gallery]({{ site.baseurl }}{% link pages/diagrams/gallery.md %})
+* [View all diagrams in a table]({{ site.baseurl }}{% link pages/diagrams/table.md %})
+* [View all diagrams in a big list _(classic approach)_]({{ site.baseurl }}{% link pages/diagrams/list.md %})
  
 View all the standard libraries
 
-* [Standard Libraries Overview]({{ site.baseurl }}/{% link pages/stdlibs/index.md %})
-* [View all standard libraries in an image gallery]({{ site.baseurl }}/{% link pages/stdlibs/gallery.md %})
-* [View all standard libraries in a table]({{ site.baseurl }}/{% link pages/stdlibs/table.md %})
-* [View all standard libraries in a big list _(classic approach)_]({{ site.baseurl }}/{% link pages/stdlibs/list.md %})
+* [Standard Libraries Overview]({{ site.baseurl }}{% link pages/stdlibs/index.md %})
+* [View all standard libraries in an image gallery]({{ site.baseurl }}{% link pages/stdlibs/gallery.md %})
+* [View all standard libraries in a table]({{ site.baseurl }}{% link pages/stdlibs/table.md %})
+* [View all standard libraries in a big list _(classic approach)_]({{ site.baseurl }}{% link pages/stdlibs/list.md %})
 
 ### Theme-Specific Pages
 

--- a/script/github-pages.sh
+++ b/script/github-pages.sh
@@ -13,6 +13,7 @@ test() {
 
   echo "Found bad links:"
   grep -r --exclude='*.svg' 'href=' _site | grep -v -e 'href="/fizzbuzz' -e 'href="http' -e 'href="#"' -e 'id="markdown-toc'
+  grep -r --exclude='*.svg' 'href=' _site | grep -e '[^:]//'
 
   echo "Found bad image sources:"
   grep -r --exclude='*.svg' 'src=' _site | grep -v -e 'src="/fizzbuzz' -e 'src="//html5shiv.googlecode.com'


### PR DESCRIPTION
Hi @The-Lum ,

I'm sorry for not returning to this project sooner.

If I remember there was still an open task in #11 that the code was not shown for all diagram variants.

This PR should solve that problem by adding expandable `<details>` blocks for all variants of a diagram and linking directly to the GitHub repository path. 

I've also slipped in a little fix for duplicate slashes on the homepage.