### PR TITLE
Organize theme variants

### DIFF
--- a/_includes/availableDiagrams.liquid
+++ b/_includes/availableDiagrams.liquid
@@ -7,7 +7,7 @@
 {% capture main_caption %}Main {{ diagram.display_name }}{% endcapture %}
 {% include figure.liquid theme=page diagram=diagram url=url caption=main_caption %}
 
-{% for variant in diagram.variants %}
-{% include figure.liquid theme=page diagram=variant url=url caption=variant.display_name %}
+{% for example in diagram.examples %}
+{% include figure.liquid theme=page diagram=example url=url caption=example.display_name %}
 {% endfor %}
 {% endfor %}

--- a/_includes/linkToPage.liquid
+++ b/_includes/linkToPage.liquid
@@ -1,0 +1,29 @@
+{% if include.relation == "after" %}
+{% assign orientation = "above" %}
+{% else %}
+{% assign orientation = "below" %}
+{% endif %}
+
+{% if include.theme %}
+{% assign linked_theme = include.theme %}
+
+{% if linked_theme.variants %}
+This theme is available in multiple variants.
+Only the main variant is shown {{ orientation }}.
+Go to the [{{ linked_theme.display_name }}]({{ linked_theme.url | relative_url }}) page to see all the theme's variants
+and all available diagrams
+{% else %}
+Go to the [{{ linked_theme.display_name }}]({{ linked_theme.url | relative_url }}) page to see all available diagrams.
+{% endif %}
+{% endif %}
+
+{% if include.diagram %}
+{% assign linked_diagram = include.diagram %}
+
+{% if linked_diagram.variants %}
+There are multiple examples available avaiable for this diagram type.
+Go to the [{{ linked_diagram.display_name }}]({{ linked_diagram.url | relative_url }}) page to see all examples in all themes.
+{% else %}
+Go to the [{{ linked_diagram.display_name }}]({{ linked_diagram.url | relative_url }}) page to see this diagram in all themes.
+{% endif %}
+{% endif %}

--- a/_includes/linkToPage.liquid
+++ b/_includes/linkToPage.liquid
@@ -21,7 +21,7 @@ Go to the [{{ linked_theme.display_name }}]({{ linked_theme.url | relative_url }
 {% assign linked_diagram = include.diagram %}
 
 {% if linked_diagram.examples %}
-There are multiple examples available avaiable for this diagram type.
+There are multiple examples available for this diagram type.
 Go to the [{{ linked_diagram.display_name }}]({{ linked_diagram.url | relative_url }}) page to see all examples in all themes.
 {% else %}
 Go to the [{{ linked_diagram.display_name }}]({{ linked_diagram.url | relative_url }}) page to see this diagram in all themes.

--- a/_includes/linkToPage.liquid
+++ b/_includes/linkToPage.liquid
@@ -20,7 +20,7 @@ Go to the [{{ linked_theme.display_name }}]({{ linked_theme.url | relative_url }
 {% if include.diagram %}
 {% assign linked_diagram = include.diagram %}
 
-{% if linked_diagram.variants %}
+{% if linked_diagram.examples %}
 There are multiple examples available avaiable for this diagram type.
 Go to the [{{ linked_diagram.display_name }}]({{ linked_diagram.url | relative_url }}) page to see all examples in all themes.
 {% else %}

--- a/_layouts/diag.html
+++ b/_layouts/diag.html
@@ -25,8 +25,8 @@ This diagram was created from the following PlantUML code:
 {% capture main_caption %}Main {{ page.display_name }}{% endcapture %}
 {% include figure.liquid theme=theme diagram=page url=url caption=main_caption %}
 
-{% for variant in page.variants %}
-{% include figure.liquid theme=theme diagram=variant url=url caption=variant.display_name %}
+{% for example in page.examples %}
+{% include figure.liquid theme=theme diagram=example url=url caption=example.display_name %}
 {% endfor %}
 {% endfor %}
 
@@ -39,7 +39,7 @@ This diagram was created from the following PlantUML code:
 {% capture main_caption %}Main {{ page.display_name }}{% endcapture %}
 {% include figure.liquid theme=skin diagram=page url=url caption=main_caption %}
 
-{% for variant in page.variants %}
-{% include figure.liquid theme=skin diagram=variant url=url caption=variant.display_name %}
+{% for example in page.examples %}
+{% include figure.liquid theme=skin diagram=example url=url caption=example.display_name %}
 {% endfor %}
 {% endfor %}

--- a/_layouts/skin.html
+++ b/_layouts/skin.html
@@ -10,7 +10,7 @@ layout: default
 <h3>Skin Code</h3>
 
 <p>
-    See <a href="https://github.com/plantuml/plantuml/tree/master/skin/{{ page.name }}.skin">PlantUML skin {{
+    See <a href="https://github.com/plantuml/plantuml/blob/master/src/main/resources/skin/{{ page.name }}.skin">PlantUML skin {{
     page.display_name }}</a> for the skin's implementation details.
 </p>
 

--- a/_layouts/theme.html
+++ b/_layouts/theme.html
@@ -22,12 +22,12 @@ layout: default
     The theme is available in different variants.
 </p>
 
-{% for variant in page.variants %}
-{% assign current_variant = site.themes | where:"name", variant.name  | first %}
+{% for variant_name in page.variants %}
+{% assign variant = site.themes | where:"name", variant_name  | first %}
 
-{% capture url %}{{ current_variant.url }}{% endcapture %}
-{% capture main_caption %}Variant {{ current_variant.display_name }}{% endcapture %}
-{% include figure.liquid theme=current_variant diagram=site.default_diagram url=url caption=main_caption %}
+{% capture url %}{{ variant.url }}{% endcapture %}
+{% capture main_caption %}Variant {{ variant.display_name }}{% endcapture %}
+{% include figure.liquid theme=variant diagram=site.default_diagram url=url caption=main_caption %}
 
 {% endfor %}
 {% endif %}

--- a/_layouts/theme.html
+++ b/_layouts/theme.html
@@ -19,7 +19,7 @@ layout: default
 <h3>Other Theme Variants</h3>
 
 <p>
-    The theme is available in different variants.
+    This theme is available in different variants.
 </p>
 
 {% for variant_name in page.variants %}

--- a/_layouts/theme.html
+++ b/_layouts/theme.html
@@ -10,7 +10,7 @@ layout: default
 <h3>Theme Code</h3>
 
 <p>
-    See <a href="https://github.com/plantuml/plantuml/tree/master/themes/puml-theme-{{ page.name }}.puml">PlantUML
+    See <a href="https://github.com/plantuml/plantuml/blob/master/src/main/resources/themes/puml-theme-{{ page.name }}.puml">PlantUML
     themes {{
     page.display_name }}</a> for the theme's implementation details.
 </p>

--- a/_layouts/theme.html
+++ b/_layouts/theme.html
@@ -10,8 +10,26 @@ layout: default
 <h3>Theme Code</h3>
 
 <p>
-    See <a href="https://github.com/plantuml/plantuml/tree/master/themes/puml-theme-{{ page.name }}.puml">PlantUML themes {{
+    See <a href="https://github.com/plantuml/plantuml/tree/master/themes/puml-theme-{{ page.name }}.puml">PlantUML
+    themes {{
     page.display_name }}</a> for the theme's implementation details.
 </p>
+
+{% if page.variants %}
+<h3>Other Theme Variants</h3>
+
+<p>
+    The theme is available in different variants.
+</p>
+
+{% for variant in page.variants %}
+{% assign current_variant = site.themes | where:"name", variant.name  | first %}
+
+{% capture url %}{{ current_variant.url }}{% endcapture %}
+{% capture main_caption %}Variant {{ current_variant.display_name }}{% endcapture %}
+{% include figure.liquid theme=current_variant diagram=site.default_diagram url=url caption=main_caption %}
+
+{% endfor %}
+{% endif %}
 
 {% include availableDiagrams.liquid %}

--- a/collections/_diagrams/Class.md
+++ b/collections/_diagrams/Class.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 2
 name: Class
 display_name: Class Diagram
-variants:
+examples:
   - name: Class-Abstract-Interface
     display_name: Class Diagram with Abstract Interface
   - name: Class-Cardinality-Generic-QualifiedAssociations

--- a/collections/_diagrams/Deployment.md
+++ b/collections/_diagrams/Deployment.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 7
 name: Deployment
 display_name: Deployment Diagram
-variants:
+examples:
   - name: DeploymentWithGroup
     display_name: Deployment Diagram with Group
 ---

--- a/collections/_diagrams/Gantt.md
+++ b/collections/_diagrams/Gantt.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 13
 name: Gantt
 display_name: Gantt Chart
-variants:
+examples:
   - name: GanttWithCalendar
     display_name: Gantt Chart with Calendar
   - name: GanttWithResources

--- a/collections/_diagrams/JSON.md
+++ b/collections/_diagrams/JSON.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 18
 name: JSON
 display_name: JSON Diagram
-variants:
+examples:
   - name: JSONwithHighlight
     display_name: JSON Diagram with Highlight
 ---

--- a/collections/_diagrams/Mindmap.md
+++ b/collections/_diagrams/Mindmap.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 15
 name: Mindmap
 display_name: Mindmap Diagram
-variants:
+examples:
   - name: MindmapWithBoxless
     display_name: Mindmap Diagram with Boxless Style
 ---

--- a/collections/_diagrams/Sequence.md
+++ b/collections/_diagrams/Sequence.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 0
 name: SequenceMainExample
 display_name: Sequence Diagram
-variants:
+examples:
   - name: Sequence
     display_name: Sequence Diagram with All Participants
   - name: SequenceGroup

--- a/collections/_diagrams/State.md
+++ b/collections/_diagrams/State.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 5
 name: State
 display_name: State Diagram
-variants:
+examples:
   - name: StateWithPoint
     display_name: State Diagram with Point
 ---

--- a/collections/_diagrams/Timing.md
+++ b/collections/_diagrams/Timing.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 8
 name: Timing
 display_name: Timing Diagram
-variants:
+examples:
   - name: TimingWithHighlight
     display_name: Timing Diagram with Highlight
 ---

--- a/collections/_diagrams/UseCase.md
+++ b/collections/_diagrams/UseCase.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 1
 name: UseCase
 display_name: Use Case Diagram
-variants:
+examples:
   - name: UseCaseWithActorStyle
     display_name: UseCase Diagram with ActorStyle
 ---

--- a/collections/_diagrams/YAML.md
+++ b/collections/_diagrams/YAML.md
@@ -3,7 +3,7 @@ author: PlantUML Maintainers
 plantuml_order: 19
 name: YAML
 display_name: YAML Diagram
-variants:
+examples:
   - name: YAMLwithHighlight
     display_name: YAML Diagram with Highlight
 ---

--- a/collections/_themes/cerulean-outline.md
+++ b/collections/_themes/cerulean-outline.md
@@ -4,8 +4,7 @@ display_name: cerulean Theme with an outline style
 author: Brett Schwarz
 main_variant: cerulean
 variants:
-  - name: cerulean
-    display_name: cerulean Theme
+  - cerulean
 ---
 Cerulean theme based off of the bootstrap theme of the same name https://bootswatch.com/cerulean/.
 

--- a/collections/_themes/cerulean-outline.md
+++ b/collections/_themes/cerulean-outline.md
@@ -1,9 +1,15 @@
 ---
 name: cerulean-outline
-display_name: cerulean-outline Theme
+display_name: cerulean Theme with an outline style
 author: Brett Schwarz
+main_variant: cerulean
+variants:
+  - name: cerulean
+    display_name: cerulean Theme
 ---
 Cerulean theme based off of the bootstrap theme of the same name https://bootswatch.com/cerulean/.
+
+This is a variant of cerulean theme with an outline style.
 
 Author
 : Brett Schwarz

--- a/collections/_themes/cerulean.md
+++ b/collections/_themes/cerulean.md
@@ -2,6 +2,9 @@
 name: cerulean
 display_name: cerulean Theme
 author: Brett Schwarz
+variants:
+  - name: cerulean-outline
+    display_name: cerulean Theme with an outline style
 ---
 Cerulean theme based off of the bootstrap theme of the same name https://bootswatch.com/cerulean/.
 

--- a/collections/_themes/cerulean.md
+++ b/collections/_themes/cerulean.md
@@ -3,8 +3,7 @@ name: cerulean
 display_name: cerulean Theme
 author: Brett Schwarz
 variants:
-  - name: cerulean-outline
-    display_name: cerulean Theme with an outline style
+  - cerulean-outline
 ---
 Cerulean theme based off of the bootstrap theme of the same name https://bootswatch.com/cerulean/.
 

--- a/collections/_themes/crt-amber.md
+++ b/collections/_themes/crt-amber.md
@@ -2,6 +2,9 @@
 name: crt-amber
 display_name: crt-amber Theme
 author: Matthew Leather
+variants:
+  - name: crt-green
+    display_name: crt-green Theme
 ---
 An orange on black theme based on monochrome CRT monitors (The colors came from https://superuser.com/a/1206781).
 

--- a/collections/_themes/crt-amber.md
+++ b/collections/_themes/crt-amber.md
@@ -3,8 +3,7 @@ name: crt-amber
 display_name: crt-amber Theme
 author: Matthew Leather
 variants:
-  - name: crt-green
-    display_name: crt-green Theme
+  - crt-green
 ---
 An orange on black theme based on monochrome CRT monitors (The colors came from https://superuser.com/a/1206781).
 

--- a/collections/_themes/crt-green.md
+++ b/collections/_themes/crt-green.md
@@ -2,6 +2,10 @@
 name: crt-green
 display_name: crt-green Theme
 author: Matthew Leather
+main_variant: crt-amber
+variants:
+  - name: crt-amber
+    display_name: crt-amber Theme
 ---
 A green on black theme based on monochrome CRT monitors (The colors came from https://superuser.com/a/1206781).
 

--- a/collections/_themes/crt-green.md
+++ b/collections/_themes/crt-green.md
@@ -4,8 +4,7 @@ display_name: crt-green Theme
 author: Matthew Leather
 main_variant: crt-amber
 variants:
-  - name: crt-amber
-    display_name: crt-amber Theme
+  - crt-amber
 ---
 A green on black theme based on monochrome CRT monitors (The colors came from https://superuser.com/a/1206781).
 

--- a/collections/_themes/cyborg-outline.md
+++ b/collections/_themes/cyborg-outline.md
@@ -4,8 +4,7 @@ display_name: cyborg Theme with an outline style
 author: Brett Schwarz
 main_variant: cyborg
 variants:
-  - name: cyborg
-    display_name: cyborg Theme
+  - cyborg
 ---
 Cyborg theme based off of the bootstrap theme of the same name, with outline colors https://bootswatch.com/cyborg/.
 

--- a/collections/_themes/cyborg-outline.md
+++ b/collections/_themes/cyborg-outline.md
@@ -1,9 +1,15 @@
 ---
 name: cyborg-outline
-display_name: cyborg-outline Theme
+display_name: cyborg Theme with an outline style
 author: Brett Schwarz
+main_variant: cyborg
+variants:
+  - name: cyborg
+    display_name: cyborg Theme
 ---
 Cyborg theme based off of the bootstrap theme of the same name, with outline colors https://bootswatch.com/cyborg/.
+
+This is a variant of cyborg theme with an outline style.
 
 Author
 : Brett Schwarz

--- a/collections/_themes/cyborg.md
+++ b/collections/_themes/cyborg.md
@@ -2,6 +2,9 @@
 name: cyborg
 display_name: cyborg Theme
 author: Brett Schwarz
+variants:
+  - name: cyborg-outline
+    display_name: cyborg Theme with an outline style
 ---
 Cyborg theme based off of the bootstrap theme of the same name https://bootswatch.com/cyborg/.
 

--- a/collections/_themes/cyborg.md
+++ b/collections/_themes/cyborg.md
@@ -3,8 +3,7 @@ name: cyborg
 display_name: cyborg Theme
 author: Brett Schwarz
 variants:
-  - name: cyborg-outline
-    display_name: cyborg Theme with an outline style
+  - cyborg-outline
 ---
 Cyborg theme based off of the bootstrap theme of the same name https://bootswatch.com/cyborg/.
 

--- a/collections/_themes/materia-outline.md
+++ b/collections/_themes/materia-outline.md
@@ -1,9 +1,15 @@
 ---
 name: materia-outline
-display_name: materia-outline Theme
+display_name: materia Theme with an outline style
 author: Brett Schwarz
+main_variant: materia
+variants:
+  - name: materia
+    display_name: materia Theme
 ---
 Materia theme based off of the bootstrap theme of the same name https://bootswatch.com/materia/.
+
+This is a variant of materia theme with an outline style.
 
 Author
 : Brett Schwarz

--- a/collections/_themes/materia-outline.md
+++ b/collections/_themes/materia-outline.md
@@ -4,8 +4,7 @@ display_name: materia Theme with an outline style
 author: Brett Schwarz
 main_variant: materia
 variants:
-  - name: materia
-    display_name: materia Theme
+  - materia
 ---
 Materia theme based off of the bootstrap theme of the same name https://bootswatch.com/materia/.
 

--- a/collections/_themes/materia.md
+++ b/collections/_themes/materia.md
@@ -2,6 +2,9 @@
 name: materia
 display_name: materia Theme
 author: Brett Schwarz
+variants:
+  - name: materia-outline
+    display_name: materia Theme with an outline style
 ---
 Materia theme based off of the bootstrap theme of the same name https://bootswatch.com/materia/
 

--- a/collections/_themes/materia.md
+++ b/collections/_themes/materia.md
@@ -3,8 +3,7 @@ name: materia
 display_name: materia Theme
 author: Brett Schwarz
 variants:
-  - name: materia-outline
-    display_name: materia Theme with an outline style
+  - materia-outline
 ---
 Materia theme based off of the bootstrap theme of the same name https://bootswatch.com/materia/
 

--- a/collections/_themes/reddress-darkblue.md
+++ b/collections/_themes/reddress-darkblue.md
@@ -2,8 +2,15 @@
 name: reddress-darkblue
 display_name: reddress-darkblue Theme
 author: Drakemor
+variants:
+  - name: reddress-darkgreen
+    display_name: reddress-darkgreen Theme
+  - name: reddress-darkorange
+    display_name: reddress-darkorange Theme
+  - name: reddress-darkred
+    display_name: reddress-darkred Theme
 ---
-A dark blue style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A dark-blue style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-darkblue.md
+++ b/collections/_themes/reddress-darkblue.md
@@ -3,12 +3,9 @@ name: reddress-darkblue
 display_name: reddress-darkblue Theme
 author: Drakemor
 variants:
-  - name: reddress-darkgreen
-    display_name: reddress-darkgreen Theme
-  - name: reddress-darkorange
-    display_name: reddress-darkorange Theme
-  - name: reddress-darkred
-    display_name: reddress-darkred Theme
+  - reddress-darkgreen
+  - reddress-darkorange
+  - reddress-darkred
 ---
 A dark-blue style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-darkgreen.md
+++ b/collections/_themes/reddress-darkgreen.md
@@ -2,8 +2,16 @@
 name: reddress-darkgreen
 display_name: reddress-darkgreen Theme
 author: Drakemor
+main_variant: reddress-darkblue
+variants:
+  - name: reddress-darkblue
+    display_name: reddress-darkblue Theme
+  - name: reddress-darkorange
+    display_name: reddress-darkorange Theme
+  - name: reddress-darkred
+    display_name: reddress-darkred Theme
 ---
-A dark green style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A dark-green style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-darkgreen.md
+++ b/collections/_themes/reddress-darkgreen.md
@@ -4,12 +4,9 @@ display_name: reddress-darkgreen Theme
 author: Drakemor
 main_variant: reddress-darkblue
 variants:
-  - name: reddress-darkblue
-    display_name: reddress-darkblue Theme
-  - name: reddress-darkorange
-    display_name: reddress-darkorange Theme
-  - name: reddress-darkred
-    display_name: reddress-darkred Theme
+  - reddress-darkblue
+  - reddress-darkorange
+  - reddress-darkred
 ---
 A dark-green style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-darkorange.md
+++ b/collections/_themes/reddress-darkorange.md
@@ -4,12 +4,9 @@ display_name: reddress-darkorange Theme
 author: Drakemor
 main_variant: reddress-darkblue
 variants:
-  - name: reddress-darkblue
-    display_name: reddress-darkblue Theme
-  - name: reddress-darkgreen
-    display_name: reddress-darkgreen Theme
-  - name: reddress-darkred
-    display_name: reddress-darkred Theme
+  - reddress-darkblue
+  - reddress-darkgreen
+  - reddress-darkred
 ---
 A dark-orange style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-darkorange.md
+++ b/collections/_themes/reddress-darkorange.md
@@ -2,8 +2,16 @@
 name: reddress-darkorange
 display_name: reddress-darkorange Theme
 author: Drakemor
+main_variant: reddress-darkblue
+variants:
+  - name: reddress-darkblue
+    display_name: reddress-darkblue Theme
+  - name: reddress-darkgreen
+    display_name: reddress-darkgreen Theme
+  - name: reddress-darkred
+    display_name: reddress-darkred Theme
 ---
-A dark orange style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A dark-orange style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-darkred.md
+++ b/collections/_themes/reddress-darkred.md
@@ -2,8 +2,16 @@
 name: reddress-darkred
 display_name: reddress-darkred Theme
 author: Drakemor
+main_variant: reddress-darkblue
+variants:
+  - name: reddress-darkblue
+    display_name: reddress-darkblue Theme
+  - name: reddress-darkgreen
+    display_name: reddress-darkgreen Theme
+  - name: reddress-darkorange
+    display_name: reddress-darkorange Theme
 ---
-A dark red style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A dark-red style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-darkred.md
+++ b/collections/_themes/reddress-darkred.md
@@ -4,12 +4,9 @@ display_name: reddress-darkred Theme
 author: Drakemor
 main_variant: reddress-darkblue
 variants:
-  - name: reddress-darkblue
-    display_name: reddress-darkblue Theme
-  - name: reddress-darkgreen
-    display_name: reddress-darkgreen Theme
-  - name: reddress-darkorange
-    display_name: reddress-darkorange Theme
+  - reddress-darkblue
+  - reddress-darkgreen
+  - reddress-darkorange
 ---
 A dark-red style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-lightblue.md
+++ b/collections/_themes/reddress-lightblue.md
@@ -3,12 +3,9 @@ name: reddress-lightblue
 display_name: reddress-lightblue Theme
 author: Drakemor
 variants:
-  - name: reddress-lightgreen
-    display_name: reddress-lightgreen Theme
-  - name: reddress-lightorange
-    display_name: reddress-lightorange Theme
-  - name: reddress-lightred
-    display_name: reddress-lightred Theme
+  - reddress-lightgreen
+  - reddress-lightorange
+  - reddress-lightred
 ---
 A light-blue style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-lightblue.md
+++ b/collections/_themes/reddress-lightblue.md
@@ -2,8 +2,15 @@
 name: reddress-lightblue
 display_name: reddress-lightblue Theme
 author: Drakemor
+variants:
+  - name: reddress-lightgreen
+    display_name: reddress-lightgreen Theme
+  - name: reddress-lightorange
+    display_name: reddress-lightorange Theme
+  - name: reddress-lightred
+    display_name: reddress-lightred Theme
 ---
-A light blue style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A light-blue style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-lightgreen.md
+++ b/collections/_themes/reddress-lightgreen.md
@@ -4,12 +4,9 @@ display_name: reddress-lightgreen Theme
 author: Drakemor
 main_variant: reddress-lightblue
 variants:
-  - name: reddress-lightblue
-    display_name: reddress-lightblue Theme
-  - name: reddress-lightorange
-    display_name: reddress-lightorange Theme
-  - name: reddress-lightred
-    display_name: reddress-lightred Theme
+  - reddress-lightblue
+  - reddress-lightorange
+  - reddress-lightred
 ---
 A light-green style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-lightgreen.md
+++ b/collections/_themes/reddress-lightgreen.md
@@ -2,8 +2,16 @@
 name: reddress-lightgreen
 display_name: reddress-lightgreen Theme
 author: Drakemor
+main_variant: reddress-lightblue
+variants:
+  - name: reddress-lightblue
+    display_name: reddress-lightblue Theme
+  - name: reddress-lightorange
+    display_name: reddress-lightorange Theme
+  - name: reddress-lightred
+    display_name: reddress-lightred Theme
 ---
-A light green style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A light-green style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-lightorange.md
+++ b/collections/_themes/reddress-lightorange.md
@@ -2,8 +2,16 @@
 name: reddress-lightorange
 display_name: reddress-lightorange Theme
 author: Drakemor
+main_variant: reddress-lightblue
+variants:
+  - name: reddress-lightblue
+    display_name: reddress-lightblue Theme
+  - name: reddress-lightgreen
+    display_name: reddress-lightgreen Theme
+  - name: reddress-lightred
+    display_name: reddress-lightred Theme
 ---
-A light orange style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A light-orange style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-lightorange.md
+++ b/collections/_themes/reddress-lightorange.md
@@ -4,12 +4,9 @@ display_name: reddress-lightorange Theme
 author: Drakemor
 main_variant: reddress-lightblue
 variants:
-  - name: reddress-lightblue
-    display_name: reddress-lightblue Theme
-  - name: reddress-lightgreen
-    display_name: reddress-lightgreen Theme
-  - name: reddress-lightred
-    display_name: reddress-lightred Theme
+  - reddress-lightblue
+  - reddress-lightgreen
+  - reddress-lightred
 ---
 A light-orange style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/reddress-lightred.md
+++ b/collections/_themes/reddress-lightred.md
@@ -2,8 +2,16 @@
 name: reddress-lightred
 display_name: reddress-lightred Theme
 author: Drakemor
+main_variant: reddress-lightblue
+variants:
+  - name: reddress-lightblue 
+    display_name: reddress-lightblue Theme
+  - name: reddress-lightgreen
+    display_name: reddress-lightgreen Theme
+  - name: reddress-lightorange
+    display_name: reddress-lightorange Theme
 ---
-A light red style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
+A light-red style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 
 Original Author
 : https://github.com/Drakemor

--- a/collections/_themes/reddress-lightred.md
+++ b/collections/_themes/reddress-lightred.md
@@ -4,12 +4,9 @@ display_name: reddress-lightred Theme
 author: Drakemor
 main_variant: reddress-lightblue
 variants:
-  - name: reddress-lightblue 
-    display_name: reddress-lightblue Theme
-  - name: reddress-lightgreen
-    display_name: reddress-lightgreen Theme
-  - name: reddress-lightorange
-    display_name: reddress-lightorange Theme
+  - reddress-lightblue 
+  - reddress-lightgreen
+  - reddress-lightorange
 ---
 A light-red style from "Red Dress" https://github.com/Drakemor/RedDress-PlantUML.
 

--- a/collections/_themes/sketchy-outline.md
+++ b/collections/_themes/sketchy-outline.md
@@ -4,8 +4,7 @@ display_name: sketchy Theme with an outline style
 author: Brett Schwarz
 main_variant: sketchy
 variants:
-  - name: sketchy
-    display_name: sketchy Theme
+  - sketchy
 ---
 sketchy-outline theme based off of the bootstrap theme of the same name https://bootswatch.com/sketchy/.
 

--- a/collections/_themes/sketchy-outline.md
+++ b/collections/_themes/sketchy-outline.md
@@ -1,9 +1,15 @@
 ---
 name: sketchy-outline
-display_name: sketchy-outline Theme
+display_name: sketchy Theme with an outline style
 author: Brett Schwarz
+main_variant: sketchy
+variants:
+  - name: sketchy
+    display_name: sketchy Theme
 ---
 sketchy-outline theme based off of the bootstrap theme of the same name https://bootswatch.com/sketchy/.
+
+This is a variant of sketchy theme with an outline style.
 
 Author
 : Brett Schwarz

--- a/collections/_themes/sketchy.md
+++ b/collections/_themes/sketchy.md
@@ -2,6 +2,9 @@
 name: sketchy
 display_name: sketchy Theme
 author: Brett Schwarz
+variants:
+  - name: sketchy-outline
+    display_name: sketchy Theme with an outline style
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/sketchy/.
 

--- a/collections/_themes/sketchy.md
+++ b/collections/_themes/sketchy.md
@@ -3,8 +3,7 @@ name: sketchy
 display_name: sketchy Theme
 author: Brett Schwarz
 variants:
-  - name: sketchy-outline
-    display_name: sketchy Theme with an outline style
+  - sketchy-outline
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/sketchy/.
 

--- a/collections/_themes/spacelab-white.md
+++ b/collections/_themes/spacelab-white.md
@@ -4,8 +4,7 @@ display_name: spacelab-white Theme
 author: Brett Schwarz
 main_variant: spacelab
 variants:
-  - name: spacelab
-    display_name: spacelab Theme
+  - spacelab
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/spacelab/
 

--- a/collections/_themes/spacelab-white.md
+++ b/collections/_themes/spacelab-white.md
@@ -2,6 +2,10 @@
 name: spacelab-white
 display_name: spacelab-white Theme
 author: Brett Schwarz
+main_variant: spacelab
+variants:
+  - name: spacelab
+    display_name: spacelab Theme
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/spacelab/
 

--- a/collections/_themes/spacelab.md
+++ b/collections/_themes/spacelab.md
@@ -2,6 +2,9 @@
 name: spacelab
 display_name: spacelab Theme
 author: Brett Schwarz
+variants:
+  - name: spacelab-white
+    display_name: spacelab-white Theme
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/spacelab/
 

--- a/collections/_themes/spacelab.md
+++ b/collections/_themes/spacelab.md
@@ -3,8 +3,7 @@ name: spacelab
 display_name: spacelab Theme
 author: Brett Schwarz
 variants:
-  - name: spacelab-white
-    display_name: spacelab-white Theme
+  - spacelab-white
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/spacelab/
 

--- a/collections/_themes/superhero-outline.md
+++ b/collections/_themes/superhero-outline.md
@@ -4,8 +4,7 @@ display_name: superhero Theme with an outline style
 author: Brett Schwarz
 main_variant: superhero
 variants:
-  - name: superhero
-    display_name: superhero Theme
+  - superhero
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/superhero/
 

--- a/collections/_themes/superhero-outline.md
+++ b/collections/_themes/superhero-outline.md
@@ -1,9 +1,15 @@
 ---
 name: superhero-outline
-display_name: superhero-outline Theme
+display_name: superhero Theme with an outline style
 author: Brett Schwarz
+main_variant: superhero
+variants:
+  - name: superhero
+    display_name: superhero Theme
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/superhero/
+
+This is a variant of superhero theme with an outline style.
 
 Author
 : Brett Schwarz

--- a/collections/_themes/superhero.md
+++ b/collections/_themes/superhero.md
@@ -3,8 +3,7 @@ name: superhero
 display_name: superhero Theme
 author: Brett Schwarz
 variants:
-  - name: superhero-outline
-    display_name: superhero Theme with an outline style
+  - superhero-outline
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/superhero/
 

--- a/collections/_themes/superhero.md
+++ b/collections/_themes/superhero.md
@@ -2,6 +2,9 @@
 name: superhero
 display_name: superhero Theme
 author: Brett Schwarz
+variants:
+  - name: superhero-outline
+    display_name: superhero Theme with an outline style
 ---
 superhero theme based off of the bootstrap theme of the same name https://bootswatch.com/superhero/
 

--- a/index.md
+++ b/index.md
@@ -57,10 +57,12 @@ View all the standard libraries
 Or jump directly to any of the pages dedicated to each theme.
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 * Go to [{{ theme.display_name }}]({{ theme.url | relative_url }}) page
   {{ theme.excerpt }}
 
+{% endunless %}
 {% endfor %}
 
 ### Skin-Specific Pages

--- a/pages/diagrams/gallery.md
+++ b/pages/diagrams/gallery.md
@@ -20,12 +20,14 @@ Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_ur
 <div class="image-gallery">
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 {% capture url %}{{ diagram.url }}#{{ theme.name }}{% endcapture %}
 {% capture caption %}{{ theme.display_name }}{% endcapture %}
 
 {% include figure.liquid theme=theme diagram=diagram url=url caption=caption %}
 
+{% endunless %}
 {% endfor %}
 
 </div>

--- a/pages/diagrams/gallery.md
+++ b/pages/diagrams/gallery.md
@@ -15,7 +15,7 @@ permalink: /diagrams/gallery.html
 
 ### {{ diagram.display_name }}
 
-Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})
+{% include linkToPage.liquid diagram=diagram relation="before" %}
 
 <div class="image-gallery">
 
@@ -32,6 +32,6 @@ Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_ur
 
 </div>
 
-Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})
+{% include linkToPage.liquid diagram=diagram relation="after" %}
 
 {% endfor %}

--- a/pages/diagrams/index.md
+++ b/pages/diagrams/index.md
@@ -17,7 +17,7 @@ permalink: /diagrams/index.html
 
 {{ diagram.excerpt }}
 
-Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})
+{% include linkToPage.liquid diagram=diagram relation="before" %}
 
 {% capture url %}{{ diagram.url }}{% endcapture %}
 {% capture caption %}{{ diagram.display_name }} shown in {{ site.default_theme.display_name }}{% endcapture %}

--- a/pages/diagrams/list.md
+++ b/pages/diagrams/list.md
@@ -18,6 +18,7 @@ permalink: /diagrams/list.html
 Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 #### {{ diagram.display_name }} shown in {{ theme.display_name }}
 {: .no_toc}
@@ -26,6 +27,7 @@ Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_ur
 
 {% include figure.liquid theme=theme diagram=diagram url=url %}
 
+{% endunless %}
 {% endfor %}
 
 Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})

--- a/pages/diagrams/list.md
+++ b/pages/diagrams/list.md
@@ -15,7 +15,7 @@ permalink: /diagrams/list.html
 
 ### {{ diagram.display_name }}
 
-Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})
+{% include linkToPage.liquid diagram=diagram relation="before" %}
 
 {% for theme in site.themes %}
 {% unless theme.main_variant %}
@@ -30,6 +30,6 @@ Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_ur
 {% endunless %}
 {% endfor %}
 
-Go to the page for the [{{ diagram.display_name }}]({{ diagram.url | relative_url }})
+{% include linkToPage.liquid diagram=diagram relation="after" %}
 
 {% endfor %}

--- a/pages/diagrams/table.md
+++ b/pages/diagrams/table.md
@@ -21,6 +21,7 @@ permalink: /diagrams/table.html
     <tbody>
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
         <tr>
             <th class="sticky">{{ theme.name }}</th>
@@ -39,6 +40,7 @@ permalink: /diagrams/table.html
 
         </tr>
 
+{% endunless %}
 {% endfor %}
 
     </tbody>

--- a/pages/skins/gallery.md
+++ b/pages/skins/gallery.md
@@ -15,7 +15,7 @@ permalink: /skins/gallery.html
 
 ### {{ skin.display_name }}
 
-Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }}).
+{% include linkToPage.liquid theme=skin relation="before" %}
 
 <div class ="image-gallery">
 
@@ -30,6 +30,6 @@ Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }}).
 
 </div>
 
-Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }}).
+{% include linkToPage.liquid theme=skin relation="after" %}
 
 {% endfor %}

--- a/pages/skins/index.md
+++ b/pages/skins/index.md
@@ -17,7 +17,7 @@ permalink: /skins/index.html
 
 {{ skin.excerpt }}
 
-Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }}).
+{% include linkToPage.liquid theme=skin relation="before" %}
 
 {% capture url %}{{ skin.url }}{% endcapture %}
 {% capture caption %}{{ site.default_diagram.display_name }} shown in {{ skin.display_name }}{% endcapture %}

--- a/pages/skins/list.md
+++ b/pages/skins/list.md
@@ -15,7 +15,7 @@ permalink: /skins/list.html
 
 ### {{ skin.display_name }}
 
-Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }})
+{% include linkToPage.liquid theme=skin relation="before" %}
 
 {% for diagram in site.diagrams %}
 
@@ -28,6 +28,6 @@ Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }})
 
 {% endfor %}
 
-Go to the page for the [{{ skin.display_name }}]({{ skin.url | relative_url }})
+{% include linkToPage.liquid theme=skin relation="after" %}
 
 {% endfor %}

--- a/pages/stdlibs/gallery.md
+++ b/pages/stdlibs/gallery.md
@@ -20,12 +20,14 @@ Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url 
 <div class="image-gallery">
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 {% capture url %}{{ stdlib.url }}#{{ theme.name }}{% endcapture %}
 {% capture caption %}{{ theme.display_name }}{% endcapture %}
 
 {% include figure.liquid theme=theme diagram=stdlib url=url caption=caption %}
 
+{% endunless %}
 {% endfor %}
 
 </div>

--- a/pages/stdlibs/gallery.md
+++ b/pages/stdlibs/gallery.md
@@ -15,7 +15,7 @@ permalink: /stdlibs/gallery.html
 
 ### {{ stdlib.display_name }}
 
-Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})
+{% include linkToPage.liquid diagram=stdlib relation="before" %}
 
 <div class="image-gallery">
 
@@ -32,6 +32,6 @@ Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url 
 
 </div>
 
-Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})
+{% include linkToPage.liquid diagram=stdlib relation="after" %}
 
 {% endfor %}

--- a/pages/stdlibs/index.md
+++ b/pages/stdlibs/index.md
@@ -17,7 +17,7 @@ permalink: /stdlibs/index.html
 
 {{ stdlib.excerpt }}
 
-Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})
+{% include linkToPage.liquid diagram=stdlib relation="before" %}
 
 {% capture url %}{{ stdlib.url }}{% endcapture %}
 {% capture caption %}{{ stdlib.display_name }} shown in {{ site.default_theme.display_name }}{% endcapture %}

--- a/pages/stdlibs/list.md
+++ b/pages/stdlibs/list.md
@@ -18,6 +18,7 @@ permalink: /stdlibs/list.html
 Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 #### {{ stdlib.display_name }} shown in {{ theme.display_name }}
 {: .no_toc}
@@ -26,6 +27,7 @@ Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url 
 
 {% include figure.liquid theme=theme diagram=stdlib url=url %}
 
+{% endunless %}
 {% endfor %}
 
 Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})

--- a/pages/stdlibs/list.md
+++ b/pages/stdlibs/list.md
@@ -15,7 +15,7 @@ permalink: /stdlibs/list.html
 
 ### {{ stdlib.display_name }}
 
-Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})
+{% include linkToPage.liquid diagram=stdlib relation="before" %}
 
 {% for theme in site.themes %}
 {% unless theme.main_variant %}
@@ -30,6 +30,6 @@ Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url 
 {% endunless %}
 {% endfor %}
 
-Go to the page for the [{{ stdlib.display_name }}]({{ stdlib.url | relative_url }})
+{% include linkToPage.liquid diagram=stdlib relation="after" %}
 
 {% endfor %}

--- a/pages/stdlibs/table.md
+++ b/pages/stdlibs/table.md
@@ -21,6 +21,7 @@ permalink: /stdlibs/table.html
     <tbody>
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
         <tr>
             <th class="sticky">{{ theme.name }}</th>
@@ -39,6 +40,7 @@ permalink: /stdlibs/table.html
 
         </tr>
 
+{% endunless %}
 {% endfor %}
 
     </tbody>

--- a/pages/themes/gallery.md
+++ b/pages/themes/gallery.md
@@ -12,6 +12,7 @@ permalink: /themes/gallery.html
 {:toc}
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 ### {{ theme.display_name }}
 
@@ -32,4 +33,5 @@ Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}
 
 Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}).
 
+{% endunless %}
 {% endfor %}

--- a/pages/themes/gallery.md
+++ b/pages/themes/gallery.md
@@ -16,7 +16,7 @@ permalink: /themes/gallery.html
 
 ### {{ theme.display_name }}
 
-Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}).
+{% include linkToPage.liquid theme=theme relation="before" %}
 
 <div class ="image-gallery">
 
@@ -31,7 +31,7 @@ Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}
 
 </div>
 
-Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}).
+{% include linkToPage.liquid theme=theme relation="after" %}
 
 {% endunless %}
 {% endfor %}

--- a/pages/themes/index.md
+++ b/pages/themes/index.md
@@ -12,6 +12,7 @@ permalink: /themes/index.html
 {:toc}
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 ### {{ theme.display_name }}
 
@@ -24,4 +25,5 @@ Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}
 
 {% include figure.liquid theme=theme diagram=site.default_diagram url=url caption=caption %}
 
+{% endunless %}
 {% endfor %}

--- a/pages/themes/index.md
+++ b/pages/themes/index.md
@@ -1,7 +1,6 @@
 ---
 permalink: /themes/index.html
 ---
-
 ## Themes Overview
 {: .no_toc}
 

--- a/pages/themes/index.md
+++ b/pages/themes/index.md
@@ -1,6 +1,7 @@
 ---
 permalink: /themes/index.html
 ---
+
 ## Themes Overview
 {: .no_toc}
 
@@ -18,7 +19,7 @@ permalink: /themes/index.html
 
 {{ theme.excerpt }}
 
-Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}).
+{% include linkToPage.liquid theme=theme relation="before" %}
 
 {% capture url %}{{ theme.url }}{% endcapture %}
 {% capture caption %}{{ site.default_diagram.display_name }} shown in {{ theme.display_name }}{% endcapture %}

--- a/pages/themes/list.md
+++ b/pages/themes/list.md
@@ -16,7 +16,7 @@ permalink: /themes/list.html
 
 ### {{ theme.display_name }}
 
-Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }})
+{% include linkToPage.liquid theme=theme relation="before" %}
 
 {% for diagram in site.diagrams %}
 
@@ -29,7 +29,7 @@ Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}
 
 {% endfor %}
 
-Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }})
+{% include linkToPage.liquid theme=theme relation="after" %}
 
 {% endunless %}
 {% endfor %}

--- a/pages/themes/list.md
+++ b/pages/themes/list.md
@@ -12,6 +12,7 @@ permalink: /themes/list.html
 {:toc}
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
 ### {{ theme.display_name }}
 
@@ -30,4 +31,5 @@ Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }}
 
 Go to the page for the [{{ theme.display_name }}]({{ theme.url | relative_url }})
 
+{% endunless %}
 {% endfor %}

--- a/pages/themes/table.md
+++ b/pages/themes/table.md
@@ -11,9 +11,11 @@ permalink: /themes/table.html
             <th>Overview</th>
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
             <th>{{ theme.name }}</th>
 
+{% endunless %}
 {% endfor %}
 
         </tr>
@@ -26,6 +28,7 @@ permalink: /themes/table.html
             <th class="sticky">{{ diagram.name }}</th>
 
 {% for theme in site.themes %}
+{% unless theme.main_variant %}
 
             <td>
 
@@ -35,6 +38,7 @@ permalink: /themes/table.html
 
             </td>
 
+{% endunless %}
 {% endfor %}
 
         </tr>


### PR DESCRIPTION
Hi @The-Lum ,

I've prepared a change similar to #11 but this time mostly dealing with themes an their variants as described in #6 .

These changes will remove the variants of a theme from the overview pages _index_, _list_, _gallery_ and _table_ and show only the main variant of each theme. For most themes the main variant is the variant without the `-outline` suffix. For others it is the first one alphabetical.

The dedicated pages for each lesser variant still exist but are now only linked to from the dedicated theme's and diagram's pages. In addition links to theme pages and diagram pages make it explicit if there exist multiple variants or examples.