### PR TITLE
🌱 Add new diagram / 🐛 fix some diagram

### DIFF
--- a/collections/_diagrams/Chart.md
+++ b/collections/_diagrams/Chart.md
@@ -1,0 +1,9 @@
+---
+name: Chart
+display_name: Chart Diagram
+author: PlantUML Maintainers
+---
+
+With PlantUML, we can display chart.
+
+See [PlantUML Chart Diagram](https://plantuml.com/chart-diagram) for more information.

--- a/collections/_diagrams/Packetdiag.md
+++ b/collections/_diagrams/Packetdiag.md
@@ -1,0 +1,9 @@
+---
+name: Packetdiag
+display_name: Packet Diagram
+author: PlantUML Maintainers
+---
+
+With PlantUML, we can display packet diagram.
+
+See [PlantUML Packet Diagram](http://alphadoc.plantuml.com/doc/markdown/en/packetdiag) for more information.

--- a/collections/_diagrams/input/Chart.puml
+++ b/collections/_diagrams/input/Chart.puml
@@ -1,0 +1,7 @@
+@startchart
+h-axis [Q1, Q2, Q3, Q4]
+v-axis "Revenue" 0 -> 100
+v2-axis "Market Share %" 0 -> 50
+bar "Sales" [45, 62, 58, 70]
+line "Market Share" [15, 20, 18, 25] v2
+@endchart

--- a/collections/_diagrams/input/Class.puml
+++ b/collections/_diagrams/input/Class.puml
@@ -1,4 +1,5 @@
 @startuml
+hide empty members
 abstract        abstract
 abstract class  "abstract class"
 annotation      annotation

--- a/collections/_diagrams/input/Nwdiag.puml
+++ b/collections/_diagrams/input/Nwdiag.puml
@@ -1,22 +1,20 @@
-@startuml
-nwdiag {
-  network DMZ {
-      address = "y.x.x.x/24"
-      web01 [address = "y.x.x.1"];
-      web02 [address = "y.x.x.2"];
-  }
+@startnwdiag
+network DMZ {
+  address = "y.x.x.x/24"
+  web01 [address = "y.x.x.1"];
+  web02 [address = "y.x.x.2"];
+}
 
-   network Internal {
-    web01;
-    web02;
-    db01 [address = "w.w.w.z", shape = database];
-  } 
+network Internal {
+web01;
+  web02;
+  db01 [address = "w.w.w.z", shape = database];
+} 
 
-    group {
-    description = "long group label";
-    web01;
-    web02;
-    db01;
-  }
+group {
+  description = "long group label";
+  web01;
+  web02;
+  db01;
 }
 @enduml

--- a/collections/_diagrams/input/Packetdiag.puml
+++ b/collections/_diagrams/input/Packetdiag.puml
@@ -1,0 +1,7 @@
+@startpacketdiag
+scale_interval = 2;
+0-7: Source Port
+8-15: Destination Port
+16-31: Sequence Number
+32-47: Acknowledgment Number
+@endpacketdiag

--- a/collections/_diagrams/input/StateWithPoint.puml
+++ b/collections/_diagrams/input/StateWithPoint.puml
@@ -2,11 +2,13 @@
 state Somp {
   state entry1 <<entryPoint>>
   state entry2 <<entryPoint>>
+  state exitA <<exitPoint>>
   state sin
+  
   entry1 --> sin
   entry2 -> sin
   sin -> sin2
-  sin2 --> exitA <<exitPoint>>
+  sin2 --> exitA
 }
 
 [*] --> entry1


### PR DESCRIPTION
This pull request introduces new diagram documentation and example files for PlantUML, as well as minor improvements to existing diagram examples. The main themes are the addition of new chart and packet diagram support, and small enhancements to clarity and correctness in diagram syntax.

**New diagram documentation and examples:**

* Added a new markdown documentation file for the Chart diagram type (`Chart.md`).
* Added a new markdown documentation file for the Packet Diagram type (`Packetdiag.md`).
* Added an example input file for the Chart diagram (`Chart.puml`).
* Added an example input file for the Packet Diagram (`Packetdiag.puml`).

**Improvements and fixes to existing diagram examples:**

* Updated the Nwdiag example to use the correct `@startnwdiag` and removed the unnecessary `@enduml` at the end for proper syntax (`Nwdiag.puml`). [[1]](diffhunk://#diff-de6b02e28957aeea5d46413a509a8439f0b91353115afaef7b081c0ba08b7700L1-R1) [[2]](diffhunk://#diff-de6b02e28957aeea5d46413a509a8439f0b91353115afaef7b081c0ba08b7700L21)
* Added `hide empty members` to the Class diagram example for cleaner output (`Class.puml`).
* Added an exit point state and improved formatting in the StateWithPoint diagram example (`StateWithPoint.puml`).